### PR TITLE
fix: forcefully add og & twitter meta due to cache

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,7 +44,21 @@
     
       <link rel="stylesheet" href="stylesheets/extra.css">
     
-    
+      <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:site" content="awscloud">
+  <meta name="twitter:title" content="AWS Lambda Powertools Python - Homepage">
+  <meta name="twitter:description" content="None">
+  <meta name="twitter:image" content="./assets/images/powertools_docs_thumbnail.png">
+  <meta name="twitter:image:alt" content="AWS Lambda Powertools Python">
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="AWS Lambda Powertools Python - Homepage">
+  <meta property="og:site_name" content="AWS Lambda Powertools Python">
+  <meta property="og:description" content="None">
+  <meta property="og:url" content="https://am29d.github.io/aws-lambda-powertools-python/">
+  <meta property="og:image" content="./assets/images/powertools_docs_thumbnail.png">
+  <meta property="og:image:type" content="image/png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
       
     
     


### PR DESCRIPTION
**Issue #, if available:**

## Description of changes:

<!--- One or two sentences as a summary of what's being changed -->

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [ ] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [ ] Update tests
* [ ] Update docs
* [ ] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/376ec0a2ac0d2a40e0af5717bef42ff84ca0d1b9/.github/semantic.yml#L2)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
